### PR TITLE
Install maiaObject.h referenced by other header files

### DIFF
--- a/maia.pro
+++ b/maia.pro
@@ -16,6 +16,7 @@ CONFIG += qt silent #debug
 target.path = $$PREFIX/lib
 
 headers.files = \
+    maiaObject.h \
     maiaXmlRpcClient.h \
     maiaXmlRpcServer.h \
 


### PR DESCRIPTION
maiaObject.h is referenced by client and server include header files so it must be installed
along with them.