### PR TITLE
Make libmaia compatible with Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,17 @@
 cmake_minimum_required(VERSION 3.6)
 project(libmaia VERSION 1.0.0 LANGUAGES CXX)
 
+if (NOT QT_VERSION_MAJOR)
+    set(QT_VERSION_MAJOR 5 CACHE STRING "Which Qt major version to look for")
+endif()
 option(BUILD_EXAMPLE "Build example" OFF)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt5Network CONFIG REQUIRED)
-find_package(Qt5Xml CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Network CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Xml CONFIG REQUIRED)
 
 set(maia_headers
     maia/maiaFault.h
@@ -28,7 +31,7 @@ set(maia_sources
 
 add_library(maia ${maia_sources} ${maia_headers})
 target_include_directories(maia PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
-target_link_libraries(maia Qt5::Network Qt5::Xml)
+target_link_libraries(maia Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Xml)
 
 if (${BUILD_EXAMPLE})
     add_subdirectory(examples)

--- a/maia/maiaObject.cpp
+++ b/maia/maiaObject.cpp
@@ -40,7 +40,7 @@ QDomElement MaiaObject::toXml(QVariant arg) {
 	//value element, we need this in each case
 	QDomElement tagValue = doc.createElement("value");
 
-	switch(arg.type()) {
+	switch(arg.userType()) {
 	case QVariant::String: {
 
 		QDomElement tagString = doc.createElement("string"); 
@@ -167,7 +167,7 @@ QDomElement MaiaObject::toXml(QVariant arg) {
 		return tagValue;
 
 	} default:
-		qDebug() << "Failed to marshal unknown variant type: " << arg.type()
+		qDebug() << "Failed to marshal unknown variant type: " << arg.typeName()
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
 		         << Qt::endl;
 #else

--- a/maia/maiaXmlRpcServerConnection.cpp
+++ b/maia/maiaXmlRpcServerConnection.cpp
@@ -218,7 +218,12 @@ bool MaiaXmlRpcServerConnection::invokeMethodWithVariants(QObject *obj,
 	QGenericReturnArgument retarg;
 	QVariant retval;
 	if(metatype != 0 && retTypeName != "void") {
-		retval = QVariant(metatype, (const void *)0);
+		retval =
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+			QVariant(metatype, (const void *)0);
+#else
+			QVariant(QMetaType(metatype), (const void *)0);
+#endif
 		retarg = QGenericReturnArgument(retval.typeName(), retval.data());
 	} else { /* QVariant */
 		retarg = QGenericReturnArgument("QVariant", &retval);

--- a/maia/maiaXmlRpcServerConnection.cpp
+++ b/maia/maiaXmlRpcServerConnection.cpp
@@ -206,7 +206,11 @@ bool MaiaXmlRpcServerConnection::invokeMethodWithVariants(QObject *obj,
 	int metatype = 0;
 	QByteArray retTypeName = getReturnType(obj->metaObject(), method, argTypes);
 	if(!retTypeName.isEmpty()  && retTypeName != "QVariant") {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		metatype = QMetaType::type(retTypeName.data());
+#else
+		metatype = QMetaType::fromName(retTypeName).id();
+#endif
 		if(metatype == 0) // lookup failed
 			return false;
 	}


### PR DESCRIPTION
Makes the Qt version that's looked for in CMake configurable.

Adjusts the source code to differences in Qt6.

Some functionality that is used in libmaia is deprecated in Qt6, but it continues to work. Some follow-up PR will need to fix the deprecations.