### PR TITLE
Client: Work around missing Authorization header

### DIFF
--- a/maia/maiaXmlRpcClient.cpp
+++ b/maia/maiaXmlRpcClient.cpp
@@ -63,6 +63,15 @@ void MaiaXmlRpcClient::setUrl(QUrl url) {
 		return;
 	
 	request.setUrl(url);
+
+	const QString userInfo = request.url().userInfo(QUrl::FullyEncoded);
+    QByteArray auth;
+	if (!userInfo.isEmpty()) {
+		// Work around QTBUG-114119
+		// "QNetworkAccessManager only tries to authenticate if the server responds with 401"
+        auth = "Basic " + userInfo.toUtf8().toBase64();
+    }
+    request.setRawHeader("Authorization", auth);
 }
 
 void MaiaXmlRpcClient::setUserAgent(QString userAgent) {


### PR DESCRIPTION
QNetworkAccessManager only sends the Authorization header after the server replies with status code 401. Not all servers do this (in particular, Maia's own XMLRPC server does not do this). Work around the issue by manually building the required Authorization header from the URL's user info.